### PR TITLE
Fixing misspell in a country name

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -98,7 +98,7 @@
                     "url": "rtmp://live-lim.twitch.tv/app"
                 },
                 {
-                    "name": "South America: Medellin, Columbia",
+                    "name": "South America: Medellin, Colombia",
                     "url": "rtmp://live-mde.twitch.tv/app"
                 },
                 {


### PR DESCRIPTION
That said "Columbia", and not "Colombia".
https://en.wikipedia.org/wiki/Medell%C3%ADn

Many people in USA are confusing with this name, but well, here is the fix :)